### PR TITLE
Add a matrix to run all tests both with and without cargo update

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,9 @@ jobs:
           - nightly
         cargo-update:
           - true
-          - false
+        include:
+          - rust: stable
+            cargo-update: false
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - name: Run tests
         run: ./tools/ci.sh
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,9 @@ jobs:
           - stable
           - beta
           - nightly
+        cargo-update:
+          - true
+          - false
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
@@ -31,6 +34,9 @@ jobs:
           components: rustfmt
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
+      - name: Update
+        if: matrix.cargo-update
+        run: cargo update
       - name: Run tests
         run: ./tools/ci.sh
   lint:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -43,9 +34,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "calculator"
@@ -53,7 +44,6 @@ version = "0.19.10"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
- "regex",
 ]
 
 [[package]]
@@ -76,9 +66,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "diff"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dirs-next"
@@ -103,28 +93,28 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "ena"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -139,15 +129,15 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -156,24 +146,21 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -181,31 +168,32 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.4"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.10.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -239,7 +227,6 @@ dependencies = [
  "diff",
  "lalrpop",
  "lalrpop-util",
- "regex",
 ]
 
 [[package]]
@@ -250,37 +237,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
-name = "log"
-version = "0.4.14"
+name = "lock_api"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
- "cfg-if",
+ "autocfg",
+ "scopeguard",
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
+name = "log"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -294,7 +279,35 @@ version = "0.1.0"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
- "regex",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -304,14 +317,13 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "pico-args",
- "regex",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -319,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
 ]
@@ -334,9 +346,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "precomputed-hash"
@@ -345,22 +357,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "rand"
-version = "0.8.3"
+name = "proc-macro2"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -368,39 +397,31 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -409,8 +430,6 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax 0.7.1",
 ]
 
@@ -428,40 +447,64 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rustix"
-version = "0.36.7"
+version = "0.37.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+checksum = "bc809f704c03a812ac71f22456c857be34185cac691a4316f27ab0f633bb9009"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "siphasher"
-version = "0.3.3"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "string_cache"
-version = "0.8.1"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
- "lazy_static",
  "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
  "phf_shared",
  "precomputed-hash",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -476,6 +519,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,16 +548,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.1"
+name = "unicode-ident"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "whitespace"
@@ -528,57 +597,132 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ dependencies = [
  "pico-args",
  "rand",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -430,14 +430,8 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
- "regex-syntax 0.7.1",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
         "lalrpop-util",
         "lalrpop",
 ]
+resolver = "2"
 
 [workspace.package]
 repository = "https://github.com/lalrpop/lalrpop"
@@ -24,4 +25,4 @@ rust-version = "1.64"
 [workspace.dependencies]
 diff = { version = "0.1.12", default_features = false }
 regex = { version = "1.8", default_features = false, features = ["std"] }
-regex-syntax = { version = "0.6", default_features = false, features = ["unicode"] }
+regex-syntax = { version = "0.6", default_features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ rust-version = "1.64"
 [workspace.dependencies]
 diff = { version = "0.1.12", default_features = false }
 regex = { version = "1.8", default_features = false, features = ["std"] }
-regex-syntax = { version = "0.6", default_features = false }
+regex-syntax = { version = "0.7", default_features = false }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,26 @@
+<a name="0.19.12"></a>
+## 0.19.12 (2023-04-28)
+
+* Add `unicode` feature to `regex-syntax` (thanks to Jan Niehusmann!)
+
+#### Compatibility note
+This is actually not fixing a `lalrpop` bug but fixing user side bugs.
+`lalrpop` doesn't directly depend on the feature. But regex from user code probably contains it.
+We will drop this dependency again in the next release.
+
+
+<a name="0.19.11"></a>
+## 0.19.11 (2023-04-28)
+
+This release is based on 0.19.9, not 0.19.10
+No feature added or other bug fixed since 0.19.9
+
+* Fix regex version dependency issues (thanks to Wilfried Chauveau!)
+
 <a name="0.19.10"></a>
-## 0.19.10 (2023-04-24)
+## ~0.19.10 (2023-04-24)~
+
+Note: This version is yanked. These changes will be included in 0.20
 
 This release fixes an incompatibility with regex.
 

--- a/doc/calculator/Cargo.toml
+++ b/doc/calculator/Cargo.toml
@@ -6,14 +6,8 @@ build = "build.rs" # <-- We added this and everything after!
 workspace = "../.."
 edition = "2021"
 
-[build-dependencies.lalrpop]
-version = "0.19.10"
-path = "../../lalrpop"
-features = ["lexer"]
+[build-dependencies]
+lalrpop = { version = "0.19.10", path = "../../lalrpop" }
 
 [dependencies]
-regex = "1"
-
-[dependencies.lalrpop-util]
-version = "0.19.10"
-path = "../../lalrpop-util"
+lalrpop-util = { version = "0.19.10", path = "../../lalrpop-util", features = ["lexer", "unicode"] }

--- a/doc/calculator/src/main.rs
+++ b/doc/calculator/src/main.rs
@@ -9,7 +9,7 @@ macro_rules! lalrpop_mod_doc {
     }
 }
 
-lalrpop_mod_doc!(pub calculator1); // syntesized by LALRPOP
+lalrpop_mod_doc!(pub calculator1); // synthesized by LALRPOP
 
 #[test]
 fn calculator1() {

--- a/doc/nobol/Cargo.toml
+++ b/doc/nobol/Cargo.toml
@@ -6,14 +6,8 @@ authors = ["Felix S Klock II <pnkfelix@pnkfx.org>"]
 build = "build.rs" # <-- We added this and everything after!
 workspace = "../.."
 
-[build-dependencies.lalrpop]
-version = "0.19.7"
-path = "../../lalrpop"
-features = ["lexer"]
+[build-dependencies]
+lalrpop = { version = "0.19.7", path = "../../lalrpop" }
 
 [dependencies]
-regex = "1"
-
-[dependencies.lalrpop-util]
-version = "0.19.7"
-path = "../../lalrpop-util"
+lalrpop-util = { version = "0.19.7", path = "../../lalrpop-util", features = ["lexer", "unicode"] }

--- a/doc/pascal/lalrpop/Cargo.toml
+++ b/doc/pascal/lalrpop/Cargo.toml
@@ -5,14 +5,13 @@ authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 build = "build.rs"
 edition = "2021"
 
-[build-dependencies.lalrpop]
-path = "../../../lalrpop"
-features = ["lexer"]
+[build-dependencies]
+lalrpop = { version = "0.19.7", path = "../../../lalrpop" }
 
 [dependencies]
-regex = "1"
 pico-args = "0.5"
 
 [dependencies.lalrpop-util]
 version = "0.19.10"
 path = "../../../lalrpop-util"
+features = ["lexer"]

--- a/doc/pascal/lalrpop/src/main.rs
+++ b/doc/pascal/lalrpop/src/main.rs
@@ -10,11 +10,7 @@ use std::time::Instant;
 
 use pico_args::Arguments;
 
-lalrpop_mod!(
-    #[allow(clippy::ptr_arg)]
-    #[allow(clippy::vec_box)]
-    pascal
-);
+lalrpop_mod!(pascal);
 
 const USAGE: &str = "
 Usage: pascal <inputs>...

--- a/doc/src/quick_start_guide.md
+++ b/doc/src/quick_start_guide.md
@@ -12,14 +12,8 @@ the following lines to your `Cargo.toml`:
 build = "build.rs" # LALRPOP preprocessing
 
 # The generated code depends on lalrpop-util.
-#
-# The generated tokenizer depends on the regex crate.
-#
-# (If you write your own tokenizer, or already have the regex
-# crate, you can skip this dependency.)
 [dependencies]
 lalrpop-util = "0.19.10"
-regex = "1"
 
 # Add a build-time dependency on the lalrpop library:
 [build-dependencies]

--- a/doc/src/tutorial/001_adding_lalrpop.md
+++ b/doc/src/tutorial/001_adding_lalrpop.md
@@ -34,7 +34,6 @@ lalrpop = "0.19.10"
 
 [dependencies]
 lalrpop-util = "0.19.10"
-regex = "1"
 ```
 
 Cargo can run [build scripts] as a pre-processing step,

--- a/lalrpop-test/Cargo.toml
+++ b/lalrpop-test/Cargo.toml
@@ -10,16 +10,15 @@ license.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
+[build-dependencies.lalrpop]
+path = "../lalrpop"
+
 [dependencies]
 diff.workspace = true
-regex.workspace = true
 
 [dependencies.lalrpop-util]
 path = "../lalrpop-util"
-
-[build-dependencies.lalrpop]
-path = "../lalrpop"
-features = ["lexer"]
+features = ["lexer", "unicode"]
 
 [features]
 default = ["test-set"]

--- a/lalrpop-test/src/cfg.lalrpop
+++ b/lalrpop-test/src/cfg.lalrpop
@@ -1,5 +1,8 @@
 grammar;
 
+pub AlwaysCreated: () = {
+};
+
 #[cfg(feature = "test-not-set")]
 pub NotCreated: () = {
 };

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -20,7 +20,6 @@ macro_rules! lalrpop_mod_test {
     ($(#[$attr:meta])* $vis:vis $modname:ident) => {
         lalrpop_mod!(
             #[allow(clippy::ptr_arg)]
-            #[allow(clippy::vec_box)]
             $(#[$attr])* $vis $modname);
     }
 }

--- a/lalrpop-test/src/lib.rs
+++ b/lalrpop-test/src/lib.rs
@@ -179,7 +179,9 @@ lalrpop_mod_test!(
 );
 
 pub fn use_cfg_created_parser() {
+    #[cfg(feature = "test-set")]
     cfg::CreatedParser::new();
+    cfg::AlwaysCreatedParser::new();
 }
 
 /// This constant is here so that some of the generator parsers can

--- a/lalrpop-util/Cargo.toml
+++ b/lalrpop-util/Cargo.toml
@@ -14,7 +14,8 @@ rust-version.workspace = true
 regex = { workspace = true, optional = true }
 
 [features]
-lexer = ["regex"]
+lexer = ["regex/std", "std"]
+unicode = ["regex?/unicode"]
 std = []
 default = ["std"]
 

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -202,6 +202,7 @@ macro_rules! lalrpop_mod {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::{format, string::ToString, vec};
 
     #[test]
     fn test() {

--- a/lalrpop-util/src/state_machine.rs
+++ b/lalrpop-util/src/state_machine.rs
@@ -1,6 +1,7 @@
 use alloc::{string::String, vec, vec::Vec};
 use core::fmt::Debug;
 
+#[cfg(feature = "std")]
 const DEBUG_ENABLED: bool = false;
 
 macro_rules! debug {

--- a/lalrpop/Cargo.toml
+++ b/lalrpop/Cargo.toml
@@ -37,22 +37,19 @@ unicode-xid = { version = "0.2", default_features = false }
 # library, disable it in your project by setting default_features = false.
 pico-args = { version = "0.5", default_features = false, optional = true }
 
+lalrpop-util = { path = "../lalrpop-util", version = "0.19.10" }
 
 [dev-dependencies]
 rand = "0.8"
 
-[dependencies.lalrpop-util]
-path = "../lalrpop-util"
-version = "0.19.10" # LALRPOP
-
 [features]
-default=["lexer", "pico-args"]
-
-# Feature used when developing LALRPOP. Tells the build script to use an existing lalrpop binary to
-# generate LALRPOPs own parser instead of using the saved parser.
-test = []
-
+default=["lexer", "unicode", "pico-args"]
+unicode = ["regex/unicode", "regex-syntax/unicode"]
 lexer = ["lalrpop-util/lexer"]
 
 [package.metadata.docs.rs]
 features = ["lexer"]
+
+[[bin]]
+name = "lalrpop"
+required-features = ["pico-args"]

--- a/lalrpop/src/build/mod.rs
+++ b/lalrpop/src/build/mod.rs
@@ -461,11 +461,12 @@ fn write_where_clause<W: Write>(
 }
 
 fn emit_to_triple_trait<W: Write>(grammar: &r::Grammar, rust: &mut RustWrite<W>) -> io::Result<()> {
-    #![allow(non_snake_case)]
-
-    let L = grammar.types.terminal_loc_type();
-    let T = grammar.types.terminal_token_type();
-    let E = grammar.types.error_type();
+    #[allow(non_snake_case)]
+    let (L, T, E) = (
+        grammar.types.terminal_loc_type(),
+        grammar.types.terminal_token_type(),
+        grammar.types.error_type(),
+    );
 
     let parse_error = format!(
         "{p}lalrpop_util::ParseError<{L}, {T}, {E}>",

--- a/lalrpop/src/lexer/nfa/mod.rs
+++ b/lalrpop/src/lexer/nfa/mod.rs
@@ -4,8 +4,7 @@
 
 use crate::lexer::re::Regex;
 use regex_syntax::hir::{
-    Anchor, Class, ClassBytesRange, ClassUnicodeRange, GroupKind, Hir, HirKind, Literal,
-    RepetitionKind, RepetitionRange,
+    Class, ClassBytesRange, ClassUnicodeRange, Hir, HirKind, Literal, Repetition,
 };
 use std::char;
 use std::fmt::{Debug, Error as FmtError, Formatter};
@@ -117,9 +116,7 @@ pub const START: NfaStateIndex = NfaStateIndex(2);
 pub enum NfaConstructionError {
     NamedCaptures,
     NonGreedy,
-    WordBoundary,
-    LineBoundary,
-    TextBoundary,
+    LookAround,
     ByteRegex,
 }
 
@@ -225,27 +222,15 @@ impl Nfa {
         accept: NfaStateIndex,
         reject: NfaStateIndex,
     ) -> Result<NfaStateIndex, NfaConstructionError> {
-        match *expr.kind() {
+        match expr.kind() {
             HirKind::Empty => Ok(accept),
 
-            HirKind::Literal(ref l) => {
-                match *l {
-                    // [s0] -otherwise-> [accept]
-                    Literal::Unicode(c) => {
-                        let s0 = self.new_state(StateKind::Neither);
-                        self.push_edge(s0, Test::char(c), accept);
-                        self.push_edge(s0, Other, reject);
-                        Ok(s0)
-                    }
-                    //// Bytes are not supported
-                    Literal::Byte(b) => {
-                        let s0 = self.new_state(StateKind::Neither);
-                        self.push_edge(s0, Test::byte(b), accept);
-                        self.push_edge(s0, Other, reject);
-                        Ok(s0)
-                    }
-                }
-            }
+            HirKind::Literal(Literal(l)) => Ok(l.iter().rev().fold(accept, |accept, &b| {
+                let s0 = self.new_state(StateKind::Neither);
+                self.push_edge(s0, Test::byte(b), accept);
+                self.push_edge(s0, Other, reject);
+                s0
+            })),
 
             HirKind::Class(ref class) => {
                 match *class {
@@ -280,65 +265,50 @@ impl Nfa {
 
             // currently we don't support any boundaries because
             // I was too lazy to code them up or think about them
-            HirKind::WordBoundary(_) => Err(NfaConstructionError::WordBoundary),
-            HirKind::Anchor(ref a) => match a {
-                Anchor::StartLine | Anchor::EndLine => Err(NfaConstructionError::LineBoundary),
-                Anchor::StartText | Anchor::EndText => Err(NfaConstructionError::TextBoundary),
-            },
+            // Akin to anchors or wordboundaries
+            HirKind::Look(_) => Err(NfaConstructionError::LookAround),
 
-            // currently we treat all groups the same, whether they
+            // currently we treat all capture groups the same, whether they
             // capture or not; but we don't permit named groups,
             // in case we want to give them significance in the future
-            HirKind::Group(ref g) => match g.kind {
-                GroupKind::CaptureName { .. } => Err(NfaConstructionError::NamedCaptures),
-                GroupKind::CaptureIndex(_) | GroupKind::NonCapturing => {
-                    self.expr(&g.hir, accept, reject)
-                }
+            HirKind::Capture(c) => match c.name {
+                Some(_) => Err(NfaConstructionError::NamedCaptures),
+                None => self.expr(&c.sub, accept, reject),
             },
 
-            HirKind::Repetition(ref r) => {
-                if !r.greedy {
+            HirKind::Repetition(Repetition {
+                min,
+                max,
+                greedy,
+                sub,
+            }) => {
+                if !greedy {
                     // currently we always report the longest match possible
                     Err(NfaConstructionError::NonGreedy)
                 } else {
-                    match r.kind {
-                        RepetitionKind::ZeroOrOne => self.optional_expr(&r.hir, accept, reject),
-                        RepetitionKind::ZeroOrMore => self.star_expr(&r.hir, accept, reject),
-                        RepetitionKind::OneOrMore => self.plus_expr(&r.hir, accept, reject),
-                        RepetitionKind::Range(ref range) => {
-                            match *range {
-                                RepetitionRange::Exactly(c) => {
-                                    let mut s = accept;
-                                    for _ in 0..c {
-                                        s = self.expr(&r.hir, s, reject)?;
-                                    }
-                                    Ok(s)
-                                }
-                                RepetitionRange::AtLeast(min) => {
-                                    // +---min times----+
-                                    // |                |
-                                    //
-                                    // [s0] --..e..-- [s1] --..e*..--> [accept]
-                                    //          |      |
-                                    //          |      v
-                                    //          +-> [reject]
-                                    let mut s = self.star_expr(&r.hir, accept, reject)?;
-                                    for _ in 0..min {
-                                        s = self.expr(&r.hir, s, reject)?;
-                                    }
-                                    Ok(s)
-                                }
-                                RepetitionRange::Bounded(min, max) => {
-                                    let mut s = accept;
-                                    for _ in min..max {
-                                        s = self.optional_expr(&r.hir, s, reject)?;
-                                    }
-                                    for _ in 0..min {
-                                        s = self.expr(&r.hir, s, reject)?;
-                                    }
-                                    Ok(s)
-                                }
-                            }
+                    match (min, max) {
+                        (0, Some(1)) => self.optional_expr(sub, accept, reject),
+                        (0, None) => self.star_expr(sub, accept, reject),
+                        (1, None) => self.plus_expr(sub, accept, reject),
+                        (_, Some(max)) if min == max => {
+                            (0..*max).try_fold(accept, |s, _| self.expr(sub, s, reject))
+                        }
+                        (_, Some(max)) => {
+                            let s = (*min..*max)
+                                .try_fold(accept, |s, _| self.optional_expr(sub, s, reject))?;
+                            (0..*min).try_fold(s, |s, _| self.expr(sub, s, reject))
+                        }
+                        (_, None) => {
+                            // +---min times----+
+                            // |                |
+                            //
+                            // [s0] --..e..-- [s1] --..e*..--> [accept]
+                            //          |      |
+                            //          |      v
+                            //          +-> [reject]
+                            self.star_expr(sub, accept, reject).and_then(|s| {
+                                (0..*min).try_fold(s, |s, _| self.expr(sub, s, reject))
+                            })
                         }
                     }
                 }

--- a/lalrpop/src/lexer/nfa/test.rs
+++ b/lalrpop/src/lexer/nfa/test.rs
@@ -114,13 +114,13 @@ fn line_boundaries() {
     let num = re::parse_regex(r#"^aBCdeF"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::TextBoundary
+        NfaConstructionError::LookAround
     );
 
     let num = re::parse_regex(r#"aBCdeF$"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::TextBoundary
+        NfaConstructionError::LookAround
     );
 }
 
@@ -129,13 +129,13 @@ fn text_boundaries() {
     let num = re::parse_regex(r#"(?m)^aBCdeF"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::LineBoundary
+        NfaConstructionError::LookAround
     );
 
     let num = re::parse_regex(r#"(?m)aBCdeF$"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::LineBoundary
+        NfaConstructionError::LookAround
     );
 }
 
@@ -144,13 +144,13 @@ fn word_boundaries() {
     let num = re::parse_regex(r#"\baBCdeF"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::WordBoundary
+        NfaConstructionError::LookAround
     );
 
     let num = re::parse_regex(r#"aBCdeF\B"#).unwrap();
     assert_eq!(
         Nfa::from_re(&num).unwrap_err(),
-        NfaConstructionError::WordBoundary
+        NfaConstructionError::LookAround
     );
 }
 

--- a/lalrpop/src/lexer/nfa/test.rs
+++ b/lalrpop/src/lexer/nfa/test.rs
@@ -82,6 +82,8 @@ fn max_range() {
 }
 
 #[test]
+// This test requires regex's unicode case support
+#[cfg_attr(not(feature = "unicode"), ignore)]
 fn literal() {
     let num = re::parse_regex(r#"(?i:aBCdeF)"#).unwrap();
     let nfa = Nfa::from_re(&num).unwrap();

--- a/lalrpop/src/lr1/build/test.rs
+++ b/lalrpop/src/lr1/build/test.rs
@@ -329,6 +329,8 @@ ty: () = {
 
 // Not sure if this is the right spot
 #[test]
+// This test requires regex's unicode case support
+#[cfg_attr(not(feature = "unicode"), ignore)]
 fn match_grammar() {
     let _tls = Tls::test();
 

--- a/lalrpop/src/lr1/codegen/base.rs
+++ b/lalrpop/src/lr1/codegen/base.rs
@@ -158,16 +158,13 @@ impl<'codegen, 'grammar, W: Write, C> CodeGenerator<'codegen, 'grammar, W, C> {
         F: FnOnce(&mut Self) -> io::Result<()>,
     {
         rust!(self.out, "");
-        rust!(self.out, "#[cfg_attr(rustfmt, rustfmt_skip)]");
-        rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
-
-        // these stylistic lints are annoying for the generated code,
-        // which doesn't follow conventions:
+        rust!(self.out, "#[rustfmt::skip]");
         rust!(
             self.out,
-            "#![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
+            "#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, \
              unused_imports, unused_parens, clippy::all)]"
         );
+        rust!(self.out, "mod {}parse{} {{", self.prefix, self.start_symbol);
         rust!(self.out, "");
 
         self.write_uses()?;

--- a/lalrpop/src/main.rs
+++ b/lalrpop/src/main.rs
@@ -11,9 +11,9 @@ use pico_args::Arguments;
 
 use lalrpop::Configuration;
 
-static VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-const USAGE: &str = "
+const USAGE: &str = "\
 Usage: lalrpop [options] <inputs>...
        lalrpop --help
        lalrpop (-V | --version)
@@ -29,7 +29,7 @@ Options:
     -c, --color          Force colorful output, even if this is not a TTY.
     --no-whitespace      Removes redundant whitespace from the generated file. (Default: false)
     --comments           Enable comments in the generated code.
-    --report             Generate report files.
+    --report             Generate report files.\
 ";
 
 #[derive(Debug)]
@@ -65,12 +65,12 @@ impl FromStr for LevelFlag {
             "info" => Ok(Info),
             "verbose" => Ok(Verbose),
             "debug" => Ok(Debug),
-            x => Err(format!("Unknown level {}", x)),
+            x => Err(format!("Unknown level: {x}")),
         }
     }
 }
 
-fn parse_args(mut args: Arguments) -> Result<Args, Box<dyn std::error::Error>> {
+fn parse_args(mut args: Arguments) -> Result<Args, pico_args::Error> {
     Ok(Args {
         flag_out_dir: args.opt_value_from_fn(["-o", "--out-dir"], PathBuf::from_str)?,
         flag_features: args.opt_value_from_str("--features")?,
@@ -86,24 +86,20 @@ fn parse_args(mut args: Arguments) -> Result<Args, Box<dyn std::error::Error>> {
     })
 }
 
-fn main() {
-    main1().unwrap();
-}
-
-fn main1() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut stderr = std::io::stderr();
     let mut stdout = std::io::stdout();
 
     let args = parse_args(Arguments::from_env())?;
 
     if args.flag_help {
-        writeln!(stdout, "{}", USAGE)?;
-        process::exit(0);
+        writeln!(stdout, "{USAGE}")?;
+        return Ok(());
     }
 
     if args.flag_version {
-        writeln!(stdout, "{}", VERSION)?;
-        process::exit(0);
+        writeln!(stdout, "{VERSION}")?;
+        return Ok(());
     }
 
     let mut config = Configuration::new();
@@ -136,14 +132,10 @@ fn main1() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if args.arg_inputs.is_empty() {
-        writeln!(
-            stderr,
-            "Error: no input files specified! Try --help for help."
-        )?;
-        process::exit(1);
+        return Err("Error: no input files specified! Try --help for help.".into());
     }
 
-    if let Some(ref out_dir) = args.flag_out_dir {
+    if let Some(out_dir) = args.flag_out_dir {
         config.set_out_dir(out_dir);
     }
 
@@ -210,7 +202,7 @@ mod test {
     #[test]
     fn test_usage_out_dir() {
         let args = parse_args_slice(&["--out-dir", "abc", "file.lalrpop"]);
-        assert_eq!(args.flag_out_dir, Some(PathBuf::from_str("abc").unwrap()));
+        assert_eq!(args.flag_out_dir.as_deref(), Some(Path::new("abc")));
         assert_eq!(args.arg_inputs, ["file.lalrpop"]);
     }
 

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -351,9 +351,7 @@ fn construct(grammar: &mut Grammar, match_block: MatchBlock) -> NormResult<()> {
             let feature = match error {
                 NamedCaptures => r#"named captures (`(?P<foo>...)`)"#,
                 NonGreedy => r#""non-greedy" repetitions (`*?` or `+?`)"#,
-                WordBoundary => r#"word boundaries (`\b` or `\B`)"#,
-                LineBoundary => r#"line boundaries (`^` or `$`)"#,
-                TextBoundary => r#"text boundaries (`^` or `$`)"#,
+                LookAround => r#"all boundaries like `\b` or `\B` or `^` or `$`"#,
                 ByteRegex => r#"byte-based matches"#,
             };
             let literal = &match_entries[index.index()].match_literal;

--- a/lalrpop/src/normalize/token_check/mod.rs
+++ b/lalrpop/src/normalize/token_check/mod.rs
@@ -34,12 +34,6 @@ pub fn validate(mut grammar: Grammar) -> NormResult<Grammar> {
                     .collect(),
             }
         } else {
-            if cfg!(not(feature = "lexer")) {
-                return_err!(
-                    Span::default(),
-                    "The `lexer` feature must be specified unless an `extern` lexer is defined"
-                );
-            }
             TokenMode::Internal {
                 match_block: MatchBlock::new(grammar.match_token())?,
             }

--- a/lalrpop/src/normalize/token_check/test.rs
+++ b/lalrpop/src/normalize/token_check/test.rs
@@ -111,6 +111,8 @@ fn regex_literals() {
 
 /// Basic test for match mappings.
 #[test]
+// This test requires regex's unicode case support
+#[cfg_attr(not(feature = "unicode"), ignore)]
 fn match_mappings() {
     check_intern_token(
         r#"grammar; match { r"(?i)begin" => "BEGIN" } else { "abc" => ALPHA } X = "BEGIN" ALPHA;"#,
@@ -125,6 +127,8 @@ fn match_mappings() {
 /// Match mappings, exercising precedence. Here the ID regex *would*
 /// be ambiguous with the begin regex.
 #[test]
+// This test requires regex's unicode case support
+#[cfg_attr(not(feature = "unicode"), ignore)]
 fn match_precedence() {
     check_intern_token(
         r#"grammar; match { r"(?i)begin" => "BEGIN" } else { r"\w+" => ID } X = ();"#,
@@ -158,12 +162,16 @@ fn invalid_match_regex_literal() {
 
 /// Test that, with a catch-all, the previous two examples work.
 #[test]
+// This test requires regex's unicode case support
+#[cfg_attr(not(feature = "unicode"), ignore)]
 fn match_catch_all() {
     let grammar = r#"grammar; match { r"(?i)begin" => "BEGIN", _ } X = { "foo", r"foo" };"#;
     assert!(validate_grammar(grammar).is_ok())
 }
 
 #[test]
+// This test requires regex's unicode case support
+#[cfg_attr(not(feature = "unicode"), ignore)]
 fn complex_match() {
     let grammar = r##"
         grammar;
@@ -182,6 +190,8 @@ fn complex_match() {
 /// Test that overlapping regular expressions are still forbidden within one level
 /// of a match declaration.
 #[test]
+// This test requires regex's unicode case support
+#[cfg_attr(not(feature = "unicode"), ignore)]
 fn ambiguity_within_match() {
     check_err(
         r##"ambiguity detected between the terminal `r#"b"#` and the terminal `r#"\(\?i\)b"#`"##,
@@ -196,8 +206,8 @@ fn ambiguity_within_match() {
 #[test]
 fn same_literal_twice() {
     check_err(
-        r##"multiple match entries for `r#"\(\?i\)b"#`"##,
-        r#"grammar; match { r"(?i)b" => "B" } else { r"(?i)b" => "b" }"#,
-        r#"                                          ~~~~~~~~~~~~~~~~ "#,
+        r##"multiple match entries for `r#"\[bB\]"#`"##,
+        r#"grammar; match { r"[bB]" => "B" } else { r"[bB]" => "b" }"#,
+        r#"                                         ~~~~~~~~~~~~~~~ "#,
     );
 }

--- a/lalrpop/src/parser/lrgrammar.rs
+++ b/lalrpop/src/parser/lrgrammar.rs
@@ -15,9 +15,9 @@ use self::___lalrpop_util::state_machine as ___state_machine;
 extern crate core;
 extern crate alloc;
 
-#[cfg_attr(rustfmt, rustfmt_skip)]
+#[rustfmt::skip]
+#[allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 mod ___parse___Top {
-#![allow(non_snake_case, non_camel_case_types, unused_mut, unused_variables, unused_imports, unused_parens, clippy::all)]
 
 use string_cache::DefaultAtom as Atom;
 use crate::grammar::parse_tree::*;

--- a/lalrpop/src/test_util.rs
+++ b/lalrpop/src/test_util.rs
@@ -62,12 +62,12 @@ pub fn check_norm_err(expected_err: &str, span: &str, err: NormError) {
     let expected_err = Regex::new(expected_err).unwrap();
     let start_index = span.find('~').unwrap();
     let end_index = span.rfind('~').unwrap() + 1;
-    assert!(start_index <= end_index);
-    assert_eq!(err.span, pt::Span(start_index, end_index));
     assert!(
         expected_err.is_match(&err.message),
         "unexpected error text `{}`, which did not match regular expression `{}`",
         err.message,
         expected_err
     );
+    assert!(start_index <= end_index);
+    assert_eq!(err.span, pt::Span(start_index, end_index));
 }

--- a/lalrpop/src/tls/mod.rs
+++ b/lalrpop/src/tls/mod.rs
@@ -17,8 +17,7 @@ struct TlsFields {
 }
 
 thread_local! {
-    static THE_TLS_FIELDS: RefCell<Option<TlsFields>> =
-        RefCell::new(None)
+    static THE_TLS_FIELDS: RefCell<Option<TlsFields>> = const { RefCell::new(None) };
 }
 
 impl Tls {
@@ -46,7 +45,7 @@ impl Tls {
         THE_TLS_FIELDS.with(|s| {
             let mut s = s.borrow_mut();
             assert!(s.is_none());
-            *s = Some(fields.clone());
+            *s = Some(fields);
         });
 
         Tls { _dummy: () }

--- a/tools/build-doc
+++ b/tools/build-doc
@@ -5,11 +5,11 @@
 # right places so that e.g. the links to the calculator and so forth
 # work correctly.
 
-ROOT=$(dirname $(dirname $0))
+ROOT=$(dirname "$(dirname "$0")")
 
 set -e
 
-cd $ROOT/doc
+cd "$ROOT/doc"
 mdbook build
 cp -rf calculator pascal whitespace book/html
 echo "Book has been built into $PWD/book/html"

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -4,8 +4,11 @@ export RUST_BACKTRACE=1
 export CARGO_INCREMENTAL=0
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
-cargo build -p lalrpop
-cargo test --all --all-features
+cargo build --bin lalrpop --features pico-args
+# build with minimal amount of features to make sure dependencies can build too.
+cargo hack build --workspace --feature-powerset --optional-deps
+# test with minimal amount of features plus a few extra on regex/regex-syntax
+cargo hack test --workspace --feature-powerset --optional-deps
 # Check the documentation examples separately so that the `lexer` feature specified in tests do not
 # leak into them
 cargo check -p calculator

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e -u -o pipefail
 
 export RUST_BACKTRACE=1


### PR DESCRIPTION
<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->