### PR TITLE
Rewrite "unicode friendly" regex characters to ascii versions if unicode

### DIFF
--- a/lalrpop/src/normalize/token_check/test.rs
+++ b/lalrpop/src/normalize/token_check/test.rs
@@ -241,3 +241,34 @@ fn same_literal_twice() {
         r#"                                         ~~~~~~~~~~~~~~~ "#,
     );
 }
+
+#[test]
+fn whitespace_rewrite() {
+    let grammar = r#"
+        grammar;
+        pub nonterm: String = {
+            r"\w+" => "word",
+            r"\s+" => "string"
+        }
+        "#;
+
+    assert!(validate_grammar(grammar).is_ok());
+
+    #[cfg(not(feature = "unicode"))]
+    check_intern_token(
+        grammar,
+        vec![
+            ("x", r##"Some((r#"(?-u\\w)+"#, "x"))"##),
+            ("\n", r##"Some((r#"(?-u\\s)+"#, "\n"))"##),
+        ],
+    );
+
+    #[cfg(feature = "unicode")]
+    check_intern_token(
+        grammar,
+        vec![
+            ("x", r##"Some((r#"\\w+"#, "x"))"##),
+            ("\n", r##"Some((r#"\\s+"#, "\n"))"##),
+        ],
+    );
+}


### PR DESCRIPTION
support is disabled

Many of the unicode issues we have been dealing with come from users who don't actually need unicode support, but they use \s or \w to match spaces or words.  The user expectation here may be that these will match ascii whitespace or ascii words, but the regex library requires unicode support to handle them.  We've previously updated the docs to point this out, but the more ergonomic thing to do might be to just support these as ascii matches by rewriting them in lalrpop before we pass them on to regex.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->