### PR TITLE
Handle windows path separators based on build os, not target

### DIFF
--- a/lalrpop-util/build.rs
+++ b/lalrpop-util/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(build_os_windows)");
+    if std::env::consts::OS.contains("windows") {
+        println!("cargo:rustc-cfg=build_os_windows");
+    }
+}

--- a/lalrpop-util/src/lib.rs
+++ b/lalrpop-util/src/lib.rs
@@ -228,14 +228,14 @@ pub struct ErrorRecovery<L, T, E> {
     pub dropped_tokens: Vec<(L, T, L)>,
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(build_os_windows))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! path_separator {
     {} => { "/" }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(build_os_windows)]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! path_separator {


### PR DESCRIPTION
target_os is what is provided by default, but we care about paths on the *build* OS.  This worked as a proxy in our tests, which didn't include cross-compiling, but fails in cross-compiling scenarios.

<!--
Thanks for your contribution!

We always run tests on the current stable version of Rust.
To avoid unexpected CI result, consider updating Rust if you're using an earlier version.

-->